### PR TITLE
Update WindowsAutopilotIntuneCommunity.psm1

### DIFF
--- a/Community Version/WindowsAutopilotIntuneCommunity/WindowsAutopilotIntuneCommunity.psm1
+++ b/Community Version/WindowsAutopilotIntuneCommunity/WindowsAutopilotIntuneCommunity.psm1
@@ -798,6 +798,8 @@ Get-AutopilotProfile | ConvertTo-AutopilotConfigurationJSON
             $oobeConfig += 1024
             if ($_.language) {
                 $json.Add("CloudAssignedLanguage", $_.language)
+                # Use the same value for region so that screen is skipped too
+                $json.Add("CloudAssignedRegion", $_.language)
             }
         }
         if ($oobeSettings.deviceUsageType -eq 'shared') {


### PR DESCRIPTION
Add logic to set CloudAssignedRegion in the generated AutopilotConfigurationFile.json so that the "choose region" OOBE screen is also skipped.