### PR TITLE
Update WindowsAutopilotIntuneCommunity.psm1

### DIFF
--- a/Community Version/WindowsAutopilotIntuneCommunity/WindowsAutopilotIntuneCommunity.psm1
+++ b/Community Version/WindowsAutopilotIntuneCommunity/WindowsAutopilotIntuneCommunity.psm1
@@ -1156,7 +1156,7 @@ New-AutopilotProfile -mode UserDrivenAAD -displayName "My testing profile" -Desc
     "deviceNameTemplate": "$OOBE_NameTemplate",
     "deviceType": "windowsPc",
     "enableWhiteGlove": $(BoolToString($OOBE_EnableWhiteGlove)),
-    "hybridAzureADJoinSkipConnectivityCheck": $(BoolToString($OOBE_SkipConnectivityChecks)),
+    "hybridAzureADJoinSkipConnectivityCheck": $(BoolToString($OOBE_SkipConnectivityCheck)),
     "outOfBoxExperienceSettings": {
         "hidePrivacySettings": $(BoolToString($OOBE_hidePrivacySettings)),
         "hideEULA": $(BoolToString($OOBE_HideEULA)),


### PR DESCRIPTION
Fixed a typo in the parameter name.  (This had already been fixed in the source WindowsAutopilotIntune module the last time Microsoft updated it.)